### PR TITLE
Remove references to the bootstrapper:

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -93,13 +93,3 @@ jobs:
         github-release release --user Tolc-Software --repo tolc --tag main-release --name "Head release" --description "This release gets updated with each commit to main" || true
         echo "Pushing the release"
         github-release upload --user Tolc-Software --repo tolc --tag main-release --name "tolc-$(uname)-main.tar.gz" --file tolc-*.tar.gz --replace
-
-    - name: Push beta release to Tolc-Software/tolc-beta
-      if: github.ref == 'refs/heads/main'
-      env:
-        GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}
-      run: |
-        echo "Checking if a new release is needed"
-        github-release release --user Tolc-Software --repo tolc-beta --tag beta-release --name "Beta release" --description "Beta release" || true
-        echo "Pushing the release"
-        github-release upload --user Tolc-Software --repo tolc-beta --tag beta-release --name "tolc-$(uname)-beta.tar.gz" --file tolc-*.tar.gz --replace

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -98,13 +98,3 @@ jobs:
         python -m pip install mkdocs-material
         cd docs/packaging
         mkdocs gh-deploy --strict --force --config-file ./mkdocs.yml
-
-    - name: Push beta release to Tolc-Software/tolc-beta
-      if: github.ref == 'refs/heads/main'
-      env:
-        GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}
-      run: |
-        echo "Checking if a new release is needed"
-        github-release release --user Tolc-Software --repo tolc-beta --tag beta-release --name "Beta release" --description "Beta release" || true
-        echo "Pushing the release"
-        github-release upload --user Tolc-Software --repo tolc-beta --tag beta-release --name "tolc-$(uname)-beta.tar.gz" --file tolc-*.tar.gz --replace

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -101,13 +101,3 @@ jobs:
         github-release release --user Tolc-Software --repo tolc --tag main-release --name "Head release" --description "This release gets updated with each commit to main" || true
         echo "Pushing the release"
         github-release upload --user Tolc-Software --repo tolc --tag main-release --name "tolc-Windows-main.tar.gz" --file tolc.tar.gz --replace
-
-    - name: Push beta release to Tolc-Software/tolc-beta
-      if: github.ref == 'refs/heads/main'
-      env:
-        GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}
-      run: |
-        echo "Checking if a new release is needed"
-        github-release release --user Tolc-Software --repo tolc-beta --tag beta-release --name "Beta release" --description "Beta release" || true
-        echo "Pushing the release"
-        github-release upload --user Tolc-Software --repo tolc-beta --tag beta-release --name "tolc-Windows-beta.tar.gz" --file tolc.tar.gz --replace

--- a/docs/packaging/docs/cmake/interface.md
+++ b/docs/packaging/docs/cmake/interface.md
@@ -1,26 +1,6 @@
 # CMake Interface #
 
-The `CMake` interface is used to gather information about the library you wish to translate to another language. It is a convenient wrapper around the `tolc` executable for those who use `CMake` as their build suite. It consists of two levels; the `bootstrapper`, to download and install `tolc` locally within your build directory, and the `CMake` modules shipped with the resulting `tolc` installation.
-
-## Bootstrapper ##
-
-The `CMake` code for the bootstrapper can be found in the [bootstrap repository](https://github.com/Tolc-Software/bootstrap-tolc-cmake). To include it in your project add the following to your root `CMakeLists.txt`:
-
-```cmake
-include(FetchContent)
-FetchContent_Declare(
-  tolc_bootstrap
-  GIT_REPOSITORY https://github.com/Tolc-Software/bootstrap-tolc-cmake
-  GIT_TAG        main
-)
-
-FetchContent_MakeAvailable(tolc_bootstrap)
-
-# Download and uses find_package to locate tolc
-get_tolc()
-```
-
-You can also download it and add it manually with `add_subdirectory(path/to/bootstrapper)`. After the call to `get_tolc` you can use any function from the `tolc CMake` interface.
+The `CMake` interface is used to gather information about the library you wish to translate to another language. It is a convenient wrapper around the `tolc` executable for those who use `CMake` as their build suite.
 
 ## Tolc CMake interface ##
 

--- a/docs/packaging/docs/guides/translating_a_cpp_library.md
+++ b/docs/packaging/docs/guides/translating_a_cpp_library.md
@@ -36,22 +36,27 @@ add_library(Math src/Demo/demo.cpp)
 target_include_directories(Math PUBLIC include)
 ```
 
-Below this code we download and install `tolc` locally into the project using [the bootstrapper](https://github.com/Tolc-Software/bootstrap-tolc-cmake)
+Below this code we download and install `tolc` locally into the project from [the release page](https://github.com/Tolc-Software/tolc/releases/tag/main-release)
 
 ```cmake
 # CMakeLists.txt
 include(FetchContent)
 FetchContent_Declare(
-  tolc_bootstrap
-  GIT_REPOSITORY https://github.com/Tolc-Software/bootstrap-tolc-cmake
-  GIT_TAG        main
+  tolc_entry
+  URL https://github.com/Tolc-Software/tolc/releases/download/main-release/tolc-${CMAKE_HOST_SYSTEM_NAME}-main.tar.gz
 )
+FetchContent_Populate(tolc_entry)
 
-FetchContent_MakeAvailable(tolc_bootstrap)
-get_tolc()
+find_package(
+  tolc
+  CONFIG
+  PATHS
+  ${tolc_entry_SOURCE_DIR}
+  REQUIRED
+  NO_DEFAULT_PATH)
 ```
 
-After the call to `get_tolc()` we are free to use the `CMake` functions available in the `tolc` installation. To create bindings for `Math` we have to call the `tolc_create_translation` function
+After the call to `find_package` we are free to use the `CMake` functions available in the `tolc` installation. To create bindings for `Math` we have to call the `tolc_create_translation` function
 
 ```cmake
 # CMakeLists.txt

--- a/docs/packaging/docs/installing.md
+++ b/docs/packaging/docs/installing.md
@@ -1,22 +1,22 @@
 # Installing
 
-The recommended and easiest way is to use the `CMake` [bootstrapper](https://github.com/Tolc-Software/bootstrap-tolc-cmake). Just drop the following lines in your `CMake` project.
+The recommended and easiest way is to use the prebuilt binaries under [the release page](https://github.com/Tolc-Software/tolc/releases/tag/main-release). To download the appropriate one for your platform you can just drop the following lines in your `CMake` project.
 
 ```CMake
 include(FetchContent)
 FetchContent_Declare(
-  tolc_bootstrap
-  GIT_REPOSITORY https://github.com/Tolc-Software/bootstrap-tolc-cmake
-  GIT_TAG        main
+  tolc_entry
+  URL https://github.com/Tolc-Software/tolc/releases/download/main-release/tolc-${CMAKE_HOST_SYSTEM_NAME}-main.tar.gz
 )
+FetchContent_Populate(tolc_entry)
 
-FetchContent_MakeAvailable(tolc_bootstrap)
-# Download and use find_package to locate tolc
-get_tolc()
+find_package(
+  tolc
+  CONFIG
+  PATHS
+  ${tolc_entry_SOURCE_DIR}
+  REQUIRED
+  NO_DEFAULT_PATH)
 ```
 
-When reconfiguring your project, the `tolc` `CMake` interface should be available automatically. Note that this requires `CMake 3.15` or later.
-
-## From the release page
-
-The latest package is available on [the release page](https://github.com/Tolc-Software/tolc-beta/releases/tag/beta-release). From here you can use the included binary or `CMake` interface to use it in your project.
+When reconfiguring your project, the `Tolc` `CMake` interface should be available automatically. Note that this requires `CMake 3.15` or later.

--- a/docs/packaging/docs/usage.md
+++ b/docs/packaging/docs/usage.md
@@ -1,6 +1,7 @@
 # Usage
 
-Given that you have installed `tolc`, either via the [bootstrapper](https://github.com/Tolc-Software/bootstrap-tolc-cmake), or by downloading the package from the [release page](https://github.com/Tolc-Software/tolc-beta/releases/tag/beta-release), you should be able to use the `CMake` interface.
+Given that you have installed `tolc` you should be able to use the `CMake` interface.
+
 ## Via `CMake`
 
 ### `tolc_create_translation`


### PR DESCRIPTION
* Since open sourcing tolc, the bootstrapper is no longer needed

* It has been replaced by simply downloading directly from the release page