### PR TITLE
v0.4.0:

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.17)
 
 project(
   tolc
-  VERSION 0.3.0
+  VERSION 0.4.0
   LANGUAGES CXX)
 
 configure_file(docs/ReleaseNotes/version.in
@@ -31,11 +31,11 @@ include(${modules}/Sanitizers.cmake)
 include(${modules}/StaticAnalyzers.cmake)
 
 include(${modules}/GetFrontend.cmake)
-get_frontend(NAME Frontend.py VERSION v0.3.0)
+get_frontend(NAME Frontend.py VERSION v0.4.0)
 copy_frontend_docs(NAME Frontend.py SRC_DIR ${frontend.py_SOURCE_DIR} COPY_TO
                    ${CMAKE_CURRENT_LIST_DIR}/docs/packaging/docs/python)
 
-get_frontend(NAME Frontend.wasm VERSION v0.4.1)
+get_frontend(NAME Frontend.wasm VERSION v0.4.2)
 copy_frontend_docs(
   NAME Frontend.wasm SRC_DIR ${frontend.wasm_SOURCE_DIR} COPY_TO
   ${CMAKE_CURRENT_LIST_DIR}/docs/packaging/docs/webassembly)

--- a/cmake/packaging/tolc/tolcCreateTranslation.cmake
+++ b/cmake/packaging/tolc/tolcCreateTranslation.cmake
@@ -68,12 +68,12 @@ function(tolc_create_bindings)
     # NOTE: Variable injected from tolcConfig file
     get_pybind11(VERSION ${tolc_pybind11_version})
     # Create the python module
-    pybind11_add_module(${tolc_target_name} ${ARG_OUTPUT}/${ARG_TARGET}.cpp
-                        SYSTEM)
+    pybind11_add_module(${tolc_target_name}
+                        ${ARG_OUTPUT}/${ARG_TARGET}_python.cpp)
   elseif(${ARG_LANGUAGE} MATCHES "wasm")
     # Assumes that the Emscripten toolchain file is used
     # Will result in a .js and a .wasm file
-    add_executable(${tolc_target_name} ${ARG_OUTPUT}/${ARG_TARGET}.cpp)
+    add_executable(${tolc_target_name} ${ARG_OUTPUT}/${ARG_TARGET}_wasm.cpp)
 
     # Export Promise as 'loadMyLib' for module 'MyLib'
     # -s MODULARIZE=1 sets it as a promise based load

--- a/cmake/packaging/tolc/tolcTranslate.cmake
+++ b/cmake/packaging/tolc/tolcTranslate.cmake
@@ -66,7 +66,7 @@ function(tolc_translate_file)
     tolc_translate_file_${ARG_MODULE_NAME} ALL
     WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
     COMMAND ${command}
-    BYPRODUCTS ${ARG_OUTPUT}/${ARG_MODULE_NAME}.cpp)
+    BYPRODUCTS ${ARG_OUTPUT}/${ARG_MODULE_NAME}_${ARG_LANGUAGE}.cpp)
 endfunction()
 
 function(tolc_translate_target)

--- a/docs/ReleaseNotes/v0.4.0.md
+++ b/docs/ReleaseNotes/v0.4.0.md
@@ -1,0 +1,22 @@
+# News #
+
+## Output ##
+
+* Renamed the bindings output file from `{library}.cpp` to `{library}_{language}.cpp`
+  * This matches what the `target` is called in `CMake`
+  * If you are using the `CMake` wrappers this is an internal change
+
+* Vastly improved the readability of the `WebAssembly` bindings
+  * Removed excessive whitespace when binding multiple namespaces
+  * Fixed indentation when using public enums within classes
+
+
+## Minor ##
+
+* Removed `SYSTEM` when creating a `CPython` library with `pybind11` since it no longer has any effect
+
+If you want to include `pybind11` as a system header then add the following *after* calling `tolc_create_bindings`:
+
+```cmake
+set_property(TARGET pybind11::pybind11 APPEND PROPERTY NO_SYSTEM_FROM_IMPORTED)
+```

--- a/docs/packaging/docs/webassembly/examples.md
+++ b/docs/packaging/docs/webassembly/examples.md
@@ -133,6 +133,7 @@ withEnum.delete();
 ```
 
 
+
 ## Enums ##
 
 
@@ -210,6 +211,7 @@ expect(company).toBe(m.MyNamespace.Carrier.Translator.Tolc);
 ```
 
 
+
 ## Functions ##
 
 
@@ -252,6 +254,7 @@ expect(m.MyNamespace.Nested.increase(2)).toBe(3);
 ```
 
 
+
 ## Global Variables ##
 
 
@@ -286,6 +289,7 @@ expect(m.charPtr).toBe("Hello world");
 expect(m.MyNamespace.i).toBe(5);
 
 ```
+
 
 
 ## Namespaces ##
@@ -328,6 +332,7 @@ expect(m.MyLib.complexFunction()).toBe(5);
 expect(m.MyLib.We.Are.Going.Pretty.Deep.meaningOfLife()).toBe('42');
 
 ```
+
 
 
 ## Smart Pointers ##
@@ -374,6 +379,7 @@ s.delete();
 ```
 
 
+
 ## std::array ##
 
 
@@ -412,6 +418,7 @@ expect(data2).toStrictEqual([0, 1]);
 ```
 
 
+
 ## std::map ##
 
 
@@ -444,6 +451,7 @@ expect(data.size()).toBe(2);
 expect(data.get(50)).toBe("Stuff");
 
 ```
+
 
 
 ## std::pair ##
@@ -487,6 +495,7 @@ expect(withFunction.sum([1, 2])).toBe(3)
 withFunction.delete();
 
 ```
+
 
 
 ## std::tuple ##
@@ -547,6 +556,7 @@ withFunction.delete();
 ```
 
 
+
 ## std::vector ##
 
 
@@ -579,4 +589,5 @@ expect(data.size()).toBe(4);
 expect(data.get(3)).toBe(3);
 
 ```
+
 

--- a/tests/packaging/systemTests/createTranslationTest/CMakeLists.txt
+++ b/tests/packaging/systemTests/createTranslationTest/CMakeLists.txt
@@ -25,3 +25,8 @@ tolc_create_bindings(
   OUTPUT
   ${CMAKE_CURRENT_BINARY_DIR}/out
   NO_ANALYTICS)
+
+set_property(
+  TARGET pybind11::pybind11
+  APPEND
+  PROPERTY NO_SYSTEM_FROM_IMPORTED)

--- a/tests/packaging/systemTests/translateFileTest/CMakeLists.txt
+++ b/tests/packaging/systemTests/translateFileTest/CMakeLists.txt
@@ -25,7 +25,7 @@ tolc_translate_file(
 
 # These will be made available to the consumer executable,
 # which will run the tests (see src/consumer.cpp)
-set(expected_out_file ${CMAKE_CURRENT_BINARY_DIR}/out/consumer.cpp)
+set(expected_out_file ${CMAKE_CURRENT_BINARY_DIR}/out/consumer_python.cpp)
 configure_file(src/check_variables.hpp.in
                ${CMAKE_CURRENT_LIST_DIR}/src/check_variables.hpp @ONLY)
 

--- a/tests/packaging/systemTests/translateLibraryTest/CMakeLists.txt
+++ b/tests/packaging/systemTests/translateLibraryTest/CMakeLists.txt
@@ -27,7 +27,7 @@ set(public_headers
     "\"${PROJECT_SOURCE_DIR}/include/consumer.hpp\",
   \"${PROJECT_SOURCE_DIR}/include/cStyleHeader.h\",
   \"${PROJECT_SOURCE_DIR}/include/SubDir/oneLevelDeep.hpp\"")
-set(expected_out_file ${CMAKE_CURRENT_BINARY_DIR}/out/consumer.cpp)
+set(expected_out_file ${CMAKE_CURRENT_BINARY_DIR}/out/consumer_python.cpp)
 set(expected_combined_header ${CMAKE_CURRENT_BINARY_DIR}/tolc/tolc_consumer.hpp)
 configure_file(src/check_variables.hpp.in
                ${CMAKE_CURRENT_LIST_DIR}/src/check_variables.hpp @ONLY)

--- a/tests/packaging/systemTests/translateLibraryWithHeaders/CMakeLists.txt
+++ b/tests/packaging/systemTests/translateLibraryWithHeaders/CMakeLists.txt
@@ -25,7 +25,7 @@ target_include_directories(consumer PRIVATE src)
 # which will run the tests (see src/consumer.cpp)
 set(public_headers "\"${PROJECT_SOURCE_DIR}/include/consumer.hpp\",
   \"${PROJECT_SOURCE_DIR}/include/SubDir/oneLevelDeep.hpp\"")
-set(expected_out_file ${CMAKE_CURRENT_BINARY_DIR}/out/consumer.cpp)
+set(expected_out_file ${CMAKE_CURRENT_BINARY_DIR}/out/consumer_python.cpp)
 set(expected_combined_header ${CMAKE_CURRENT_BINARY_DIR}/tolc/tolc_consumer.hpp)
 configure_file(src/check_variables.hpp.in
                ${CMAKE_CURRENT_LIST_DIR}/src/check_variables.hpp @ONLY)


### PR DESCRIPTION
* Better readability for webassembly bindings

* output file is now `{lib}_{lang}.cpp` instead of `{lib}.cpp`